### PR TITLE
Revert appsettings development

### DIFF
--- a/TelegramBot/appsettings.Development.json
+++ b/TelegramBot/appsettings.Development.json
@@ -1,57 +1,9 @@
-﻿{
-	"Kestrel": {
-		"Endpoints": {
-			"Http": {
-				"Url": "http://127.0.0.1:5000"
-			}
-		}
-	},
-	"Serilog": {
-		"Using": [
-			"Serilog.Sinks.Console"
-		],
-		"MinimumLevel": {
-			"Default": "Information",
-			"Override": {
-				"Microsoft": "Error"
-			}
-		},
-		"WriteTo": [
-			{
-				"Name": "Console",
-				"Args": {
-					"formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
-				}
-			},
-			{
-				"Name": "File",
-				"Args": {
-					"path": "Logs\\TelegramBot.log",
-					"rollOnFileSizeLimit": true,
-					"shared": true,
-					"formatter": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact"
-				}
-			}
-		]
-	},
-	"AllowedHosts": "*",
-	"TelegramBotConfiguration": {
-		"RefreshIntervalInMilliseconds": 1000,
-		"TelegramOrgUrl": "api.telegram.org",
-		"GetUpdatesEndpoint": "getUpdates",
-		"SendMessageEndpoint": "sendMessage",
-		"RegisteredUsersConfiguration": {
-			"Path": "Registry\\registeredUsers.json"
-		},
-		"ProcessedMessagesConfiguration": {
-			"Path": "Registry\\processedMessages.json"
-		}
-	},
-	"UserMessageReplyConfiguration": {
-		"NewsNotificationText": "За више информација посјетите адресу: ",
-		"StartCommandReplyText": "Корисник успјешно пријављен.",
-		"StopCommandReplyText": "Корисник успјешно одјављен.",
-		"UnsupportedCommandReplyText": "Непозната команда. Подржане команде су: /start и /stop",
-		"UnregisteredUserSentMessageText": "Корисник није пријављен. Да бисте се пријавили изаберите команду /start"
-	}
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
 }


### PR DESCRIPTION
Reverted appsettings.development.json, because it had no reason to be altered from its original version.
It was aimed to be done as way of providing https support when the bot is run in development.